### PR TITLE
Allow sending `symbols` param in ticker!

### DIFF
--- a/lib/binance/api.rb
+++ b/lib/binance/api.rb
@@ -57,12 +57,18 @@ module Binance
         Request.send!(path: "/api/v1/ping")
       end
 
-      def ticker!(symbol: nil, type: nil, api_key: nil, api_secret_key: nil)
+      def ticker!(symbol: nil, symbols: nil, type: nil, api_key: nil, api_secret_key: nil)
         ticker_type = type&.to_sym
         error_message = "type must be one of: #{ticker_types.join(", ")}. #{type} was provided."
         raise Error.new(message: error_message) unless ticker_types.include? ticker_type
         path = ticker_path(type: ticker_type)
-        params = symbol ? { symbol: symbol } : {}
+        params = if symbol
+          { symbols: symbol }
+        elsif symbols
+          { symbols: symbols.to_s.delete(' ') }
+        else
+          {}
+        end
         Request.send!(api_key_type: :read_info, path: path, params: params,
                       api_key: api_key, api_secret_key: api_secret_key)
       end

--- a/spec/binance/api_spec.rb
+++ b/spec/binance/api_spec.rb
@@ -312,8 +312,9 @@ RSpec.describe Binance::Api do
 
   describe "#ticker!" do
     let(:symbol) { nil }
+    let(:symbols) { nil }
 
-    subject { Binance::Api.ticker!(symbol: symbol, type: type) }
+    subject { Binance::Api.ticker!(symbol: symbol, symbols: symbols, type: type) }
 
     shared_examples "a valid ticker request" do
       shared_examples "valid api responses" do
@@ -340,6 +341,12 @@ RSpec.describe Binance::Api do
 
       context "when symbol is not nil" do
         let(:symbol) { "BTCLTC" }
+
+        include_examples "valid api responses"
+      end
+
+      context "when symbols is not nil" do
+        let(:symbols) { ["BTCLTC", "DOTUSDT"] }
 
         include_examples "valid api responses"
       end
@@ -386,6 +393,7 @@ RSpec.describe Binance::Api do
       let!(:request_stub) do
         url = "https://api.binance.com/api/v3/ticker/price"
         url += "?symbol=#{symbol}" if symbol
+        url += "?symbols=#{symbols.to_s.delete(" ")}" if symbols
         stub_request(:get, url).to_return(stub_response)
       end
       let(:type) { :price }


### PR DESCRIPTION
https://binance-docs.github.io/apidocs/spot/en/#symbol-price-ticker

ticker endpoints supports sending an array of symbols and the current ticker! method does not allow you to do that, you can get info only about a single symbol. So extending that method to get an ability to request an information about multiple symbols in one request